### PR TITLE
Restrict user signups to Colby College email addresses for domain int…

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -26,6 +26,11 @@ def signup():
         email = request.form.get("email", "").strip().lower()
         password = request.form.get("password", "").strip()
         confirm_password = request.form.get("confirm_password", "").strip()
+        
+        # Restrict signup to Colby College emails only
+        if not email.endswith("@colby.edu"):
+            flash("Please use your Colby College email address.", "danger")
+            return redirect(url_for("auth.signup"))
 
         # Check if user already exists
         existing_user = User.query.filter_by(email=email).first()


### PR DESCRIPTION
…egrity and security

## Description
This PR adds a new validation rule to restrict user signups to only those with a `@colby.edu` email address.  
It ensures that only verified Colby College community members can create accounts on the ColbyNow Merchandise platform.


## Changes Made
- Added domain validation logic in the `signup()` route inside **`app/auth.py`**
- Implemented a check to reject any signup attempt with a non-`@colby.edu` email
- Displayed a clear flash message for invalid email domains

## Why This Change?
This update enhances platform security and integrity by ensuring that only members of the Colby College community can create marketplace accounts.  It prevents unauthorized users from registering and aligns the system with institutional access policies.

## Issues
This PR closes issue #22 
