### PR TITLE
Add multi-select filtering for Buy Item page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -59,23 +59,20 @@ def home():
 @main.route("/buy_item")
 @login_required
 def buy_item():
-    """
-    Displays all items available for purchase with filtering and sorting.
-    """
-    category = request.args.get("category", type=str)
-    seller_type = request.args.get("seller_type", type=str)
-    condition = request.args.get("condition", type=str)
+    categories_selected = request.args.getlist("category")
+    seller_types_selected = request.args.getlist("seller_type")
+    conditions_selected = request.args.getlist("condition")
     search = request.args.get("search", type=str)
     sort_by = request.args.get("sort_by", default="newest", type=str)
 
     query = Item.search(search)
 
-    if category:
-        query = query.filter_by(category=category)
-    if seller_type:
-        query = query.filter_by(seller_type=seller_type)
-    if condition:
-        query = query.filter_by(condition=condition)
+    if categories_selected:
+        query = query.filter(Item.category.in_(categories_selected))
+    if seller_types_selected:
+        query = query.filter(Item.seller_type.in_(seller_types_selected))
+    if conditions_selected:
+        query = query.filter(Item.condition.in_(conditions_selected))
 
     if sort_by == "newest":
         query = query.order_by(Item.created_at.desc())
@@ -90,14 +87,9 @@ def buy_item():
 
     items = query.all()
 
-    all_categories = db.session.query(Item.category).distinct().all()
-    categories = [cat[0] for cat in all_categories if cat[0]]
-
-    all_seller_types = db.session.query(Item.seller_type).distinct().all()
-    seller_types = [st[0] for st in all_seller_types if st[0]]
-
-    all_conditions = db.session.query(Item.condition).distinct().all()
-    conditions = [cond[0] for cond in all_conditions if cond[0]]
+    categories = [c[0] for c in db.session.query(Item.category).distinct().all() if c[0]]
+    seller_types = [s[0] for s in db.session.query(Item.seller_type).distinct().all() if s[0]]
+    conditions = [c[0] for c in db.session.query(Item.condition).distinct().all() if c[0]]
 
     return render_template(
         "buy_item.html",
@@ -105,13 +97,14 @@ def buy_item():
         categories=categories,
         seller_types=seller_types,
         conditions=conditions,
-        current_category=category,
-        current_seller_type=seller_type,
-        current_condition=condition,
+        categories_selected=categories_selected,
+        seller_types_selected=seller_types_selected,
+        conditions_selected=conditions_selected,
         current_search=search,
         current_sort=sort_by,
         item_count=len(items),
     )
+
 
 
 @main.route("/post-item", methods=["GET", "POST"])

--- a/app/templates/buy_item.html
+++ b/app/templates/buy_item.html
@@ -60,13 +60,15 @@
                         <h6 class="fw-medium mb-2">Categories</h6>
                         {% for cat in categories %}
                         <div class="form-check">
-                            <input class="form-check-input category-checkbox" type="checkbox" name="category"
-                                value="{{ cat }}" id="cat-{{ cat|lower|replace(' ', '-') }}" {% if current_category==cat
-                                %}checked{% endif %} onchange="this.form.submit()">
-                            <label class="form-check-label" for="cat-{{ cat|lower|replace(' ', '-') }}">{{ cat
-                                }}</label>
+                            <input class="form-check-input category-checkbox" type="checkbox" 
+                                name="category" value="{{ cat }}"
+                                id="cat-{{ cat|lower|replace(' ', '-') }}"
+                                {% if categories_selected and cat in categories_selected %}checked{% endif %}
+                                onchange="this.form.submit()">
+                            <label class="form-check-label" for="cat-{{ cat|lower|replace(' ', '-') }}">{{ cat }}</label>
                         </div>
                         {% endfor %}
+
                     </div>
 
                     <!-- Seller Type Filter -->
@@ -74,12 +76,15 @@
                         <h6 class="fw-medium mb-2">Seller type</h6>
                         {% for st in seller_types %}
                         <div class="form-check">
-                            <input class="form-check-input" type="checkbox" name="seller_type" value="{{ st }}"
-                                id="seller-{{ st|lower }}" {% if current_seller_type==st %}checked{% endif %}
+                            <input class="form-check-input" type="checkbox"
+                                name="seller_type" value="{{ st }}"
+                                id="seller-{{ st|lower }}"
+                                {% if seller_types_selected and st in seller_types_selected %}checked{% endif %}
                                 onchange="this.form.submit()">
                             <label class="form-check-label" for="seller-{{ st|lower }}">{{ st }}</label>
                         </div>
                         {% endfor %}
+
                     </div>
 
                     <!-- Conditions Filter -->
@@ -87,13 +92,15 @@
                         <h6 class="fw-medium mb-2">Conditions</h6>
                         {% for cond in conditions %}
                         <div class="form-check">
-                            <input class="form-check-input" type="checkbox" name="condition" value="{{ cond }}"
-                                id="cond-{{ cond|lower|replace(' ', '-') }}" {% if current_condition==cond %}checked{%
-                                endif %} onchange="this.form.submit()">
-                            <label class="form-check-label" for="cond-{{ cond|lower|replace(' ', '-') }}">{{ cond
-                                }}</label>
+                            <input class="form-check-input" type="checkbox"
+                                name="condition" value="{{ cond }}"
+                                id="cond-{{ cond|lower|replace(' ', '-') }}"
+                                {% if conditions_selected and cond in conditions_selected %}checked{% endif %}
+                                onchange="this.form.submit()">
+                            <label class="form-check-label" for="cond-{{ cond|lower|replace(' ', '-') }}">{{ cond }}</label>
                         </div>
                         {% endfor %}
+
                     </div>
                 </form>
             </aside>


### PR DESCRIPTION
# Description #
Adds full multi-select filtering to the Buy Item page so users can filter by multiple categories, seller types, and conditions simultaneously.

# Changes Made

Updated buy_item route to accept multiple values for each filter
Replaced filter_by() with filter(Item.field.in_(...))
Updated template checkboxes to support multiple selections
Added context variables to retain selected filters

# Why This Change? #
Improves search accuracy and user experience by allowing more flexible filtering instead of being limited to one option per filter group.

# Issues #

Closes issue #49