### PR TITLE
Fix seller profile picture reference in template

### DIFF
--- a/app/templates/sellers_details.html
+++ b/app/templates/sellers_details.html
@@ -38,7 +38,7 @@
                 <div class="bg-white p-3 rounded border shadow-sm">
 
                     <!-- Line 91: Handle missing profile picture -->
-                    <img src="{{ seller.profile_picture_url if seller.profile_picture_url else url_for('static', filename='images/default_user_profile.png') }}"
+                    <img src="{{ url_for('static', filename=seller.profile_image or 'images/default_user_profile.png') }}"
                         class="img-fluid rounded" alt="{{ seller.name }}'s profile picture">
                 </div>
             </div>


### PR DESCRIPTION
## Description
This PR fixes a bug in the seller details page where the seller's profile picture would not load correctly because it was referencing a non-existent property on the user model.

## Changes Made
- Updated [app/templates/sellers_details.html](cci:7://file:///Users/francis-ohara/projects/Colby-Now-Merchandise/app/templates/sellers_details.html:0:0-0:0) to reference `seller.profile_image` instead of `seller.profile_picture_url`.

## Why This Change?
The template was previously checking `seller.profile_picture_url`, which does not exist on the User model. This caused the check to fail and fall back to the default image every time, even if the user had uploaded a custom profile picture.

## Issues
This PR closes issue #69 