### PR TITLE
CI: Automatically upgrade production database on every Heroku Deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn run:app
-release flask db upgrade
+release: flask db upgrade


### PR DESCRIPTION
## Description
This PR adds release command for automatically upgrading the production database on Heroku with the latest migration scripts every time there is a new deployment that updates the database schema.

## Changes Made
- Added `release` command to `Procfile` that auto upgrades the database.


## Why This Change?
This change is necessary to prevent crashes caused by schema mismatches that occur when any new PR updates the database schema.

## Issues
This PR closes issue #79
