### PR TITLE
Refactor footer into reusable shared component

### DIFF
--- a/app/templates/_footer.html
+++ b/app/templates/_footer.html
@@ -1,0 +1,174 @@
+<!-- ===== Footer ===== -->
+<footer class="site-footer">
+
+  <!-- Back to Top -->
+  <div class="back-to-top-wrapper">
+    <button class="back-to-top-btn"
+            onclick="window.scrollTo({ top: 0, behavior: 'smooth' })">
+      ↑ Back to top
+    </button>
+  </div>
+
+  <style>
+    /* ===== Footer Base ===== */
+    .site-footer {
+      background: linear-gradient(180deg, #273555 0%, #000c2a 100%);
+      color: #ffffff;
+      padding: 2.5rem 1.5rem 1.5rem;
+      border-top: 1px solid rgba(255, 255, 255, 0.12);
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    }
+
+    /* ===== Back to Top ===== */
+    .back-to-top-wrapper {
+      display: flex;
+      justify-content: center;
+      max-width: 1000px;
+      margin: 0 auto 2rem;
+    }
+
+    .back-to-top-btn {
+      background-color: rgba(255, 255, 255, 0.08);
+      color: #ffffff;
+      border: none;
+      border-radius: 999px;
+      padding: 0.45rem 1rem;
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: background-color 0.15s ease;
+    }
+
+    .back-to-top-btn:hover {
+      background-color: rgba(255, 255, 255, 0.15);
+    }
+
+    /* ===== Layout ===== */
+    .footer-container {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 2.5rem;
+      max-width: 1000px;
+      margin: 0 auto;
+    }
+
+    @media (min-width: 768px) {
+      .footer-container {
+        grid-template-columns: repeat(3, minmax(220px, 1fr));
+        gap: 4rem;
+        text-align: left;
+      }
+    }
+
+    /* ===== Typography ===== */
+    .footer-column h4 {
+      font-size: 0.95rem;
+      font-weight: 600;
+      margin-bottom: 0.75rem;
+      color: #ffffff;
+    }
+
+    .footer-column p,
+    .footer-column li {
+      font-size: 0.9rem;
+      line-height: 1.6;
+      margin: 0.25rem 0;
+      color: rgba(255, 255, 255, 0.9);
+    }
+
+    .footer-column ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .footer-column li {
+      margin-bottom: 0.35rem;
+    }
+
+    /* ===== Links ===== */
+    .footer-column a {
+      color: rgba(255, 255, 255, 0.9);
+      text-decoration: none;
+    }
+
+    .footer-column a:hover {
+      text-decoration: underline;
+    }
+
+    /* ===== Disabled ===== */
+    .coming-soon {
+      color: rgba(255, 255, 255, 0.55);
+      cursor: default;
+    }
+
+    /* ===== Footer Bottom ===== */
+    .footer-bottom {
+      margin-top: 2.5rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: rgba(255, 255, 255, 0.7);
+    }
+
+    
+    @media (max-width: 767px) {
+      .footer-column {
+        text-align: center;
+      }
+    }
+  </style>
+
+  <div class="footer-container">
+
+    <!-- Quick Links -->
+    <div class="footer-column">
+      <h4>Quick Links</h4>
+      <ul>
+        <li><a href="{{ url_for('main.home') }}">Home</a></li>
+        <li><a href="{{ url_for('main.buy_item') }}">Browse Items</a></li>
+        <li><a href="{{ url_for('main.post_item') }}">Post an Item</a></li>
+        <li><a href="{{ url_for('main.contact_us') }}">Contact Us</a></li>
+        <li><span class="coming-soon">FAQs</span></li>
+      </ul>
+    </div>
+
+    <!-- About Mule Mart -->
+    <div class="footer-column">
+      <h4>About Mule Mart</h4>
+      <ul>
+        <li><span class="coming-soon">How It Works</span></li>
+        <li><span class="coming-soon">Community Guidelines</span></li>
+        <li><span class="coming-soon">Privacy & Data Use</span></li>
+      </ul>
+    </div>
+
+    <!-- Support -->
+    <div class="footer-column">
+      <h4>Support</h4>
+      <p>
+        Email:
+        <a href="mailto:colbynowmerchandise@gmail.com">
+          colbynowmerchandise@gmail.com
+        </a>
+      </p>
+      <p>
+        Live chat:
+        <a href="#" onclick="openLiveChat()">Start chat</a>
+      </p>
+      <p>
+        <span class="coming-soon">Join our newsletter</span>
+      </p>
+    </div>
+
+  </div>
+
+  <div class="footer-bottom">
+    © 2025, Mule Mart, BitWise CacheFlow
+  </div>
+
+</footer>
+
+<script>
+  function openLiveChat() {
+    console.log("Live chat opened");
+  }
+</script>

--- a/app/templates/_footer.html
+++ b/app/templates/_footer.html
@@ -146,8 +146,8 @@
       <h4>Support</h4>
       <p>
         Email:
-        <a href="mailto:colbynowmerchandise@gmail.com">
-          colbynowmerchandise@gmail.com
+        <a href="mailto:support@mulemart.com">
+          support@mulemart.com
         </a>
       </p>
       <p>
@@ -161,9 +161,7 @@
 
   </div>
 
-  <div class="footer-bottom">
-    © 2025, Mule Mart, BitWise CacheFlow
-  </div>
+  <div class="footer-bottom">© Mule Mart</div>
 
 </footer>
 
@@ -171,4 +169,16 @@
   function openLiveChat() {
     console.log("Live chat opened");
   }
+
+  function setFooterCopyrightText() {
+    const footerCopyrightText = document.querySelector(".footer-bottom");
+    const currentYear = new Date().getFullYear();
+    if (footerCopyrightText) {
+      footerCopyrightText.textContent = `© ${currentYear} Mule Mart`;
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    setFooterCopyrightText();
+  });
 </script>

--- a/app/templates/buy_item.html
+++ b/app/templates/buy_item.html
@@ -175,14 +175,7 @@
         </div>
     </main>
 
-    <!-- Footer -->
-    <footer class="border-top mt-5">
-        <div class="container py-4">
-            <p class="text-center text-muted small">
-                COPYRIGHTS MULEMART.COM. ALL RIGHTS RESERVED
-            </p>
-        </div>
-    </footer>
+    {% include '_footer.html' %}
 
     <!-- Load Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"

--- a/app/templates/chat.html
+++ b/app/templates/chat.html
@@ -53,47 +53,7 @@
 
     <!-- End of Main Content -->
 
-    <footer class="bg-light border-top mt-5 pt-5">
-        <div class="container-xl py-5">
-            <div class="row justify-content-between align-items-center gy-4">
-
-                <div class="col-md-6 col-lg-5">
-                    <h3 class="fs-2 fw-bold text-dark mb-2">Sign up for our newsletter</h3>
-                    <p class="text-secondary mb-4">Be the first to know about our special offers, news, and updates.</p>
-                    <form class="d-flex gap-2">
-                        <input type="email" placeholder="Email Address" class="form-control py-3">
-                        <button type="submit" class="btn btn-dark px-4">
-                            Sign Up
-                        </button>
-                    </form>
-                </div>
-
-                <div class="col-md-6 col-lg-auto">
-                    <nav class="d-flex flex-wrap justify-content-center justify-content-md-end gap-3 gap-lg-4">
-                        <a href="{{ url_for('main.home') }}"
-                            class="text-secondary text-decoration-none fw-medium">Home</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">About</a>
-                        <a href="{{ url_for('main.buy_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Browse Items</a>
-                        <a href="{{ url_for('main.post_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Post an Item</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">FAQs</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">Contact Us</a>
-                    </nav>
-                </div>
-            </div>
-        </div>
-
-        <div class="py-4 text-white-50" style="background-color: #002878;">
-            <div class="container-xl">
-                <div class="d-flex flex-column flex-sm-row justify-content-between text-center text-sm-start"
-                    style="font-size: 0.75rem;">
-                    <p class="mb-2 mb-sm-0">&copy; 2026 Mule Mart</p>
-                    <p>COPYRIGHTS MULEMART.COM. ALL RIGHTS RESERVED</p>
-                </div>
-            </div>
-        </div>
-    </footer>
+    {% include '_footer.html' %}
 
     <!-- Load Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"

--- a/app/templates/contact_us.html
+++ b/app/templates/contact_us.html
@@ -128,6 +128,8 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
         crossorigin="anonymous"></script>
+
+    {% include '_footer.html' %}
 </body>
 
 </html>

--- a/app/templates/edit_item.html
+++ b/app/templates/edit_item.html
@@ -200,6 +200,8 @@
         })
 
     </script>
+
+    {% include '_footer.html' %}
 </body>
 
 </html>

--- a/app/templates/favorites.html
+++ b/app/templates/favorites.html
@@ -68,6 +68,8 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
         crossorigin="anonymous"></script>
+
+    {% include '_footer.html' %}
 </body>
 
 </html>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -100,46 +100,7 @@
 
 
 
-    <footer class="bg-light border-top mt-5 pt-5">
-        <div class="container-xl py-5">
-            <div class="row justify-content-between align-items-center gy-4">
-
-                <div class="col-md-6 col-lg-5">
-                    <h3 class="fs-2 fw-bold text-dark mb-2">Sign up for our newsletter</h3>
-                    <p class="text-secondary mb-4">Be the first to know about our special offers, news, and updates.</p>
-                    <form class="d-flex gap-2">
-                        <input type="email" placeholder="Email Address" class="form-control py-3">
-                        <button type="submit" class="btn btn-dark px-4">
-                            Sign Up
-                        </button>
-                    </form>
-                </div>
-
-                <div class="col-md-6 col-lg-auto">
-                    <nav class="d-flex flex-wrap justify-content-center justify-content-md-end gap-3 gap-lg-4">
-                        <a href="{{ url_for('main.home') }}"
-                            class="text-secondary text-decoration-none fw-medium">Home</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">About</a>
-                        <a href="{{ url_for('main.buy_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Browse Items</a>
-                        <a href="" class="text-secondary text-decoration-none fw-medium">Post an Item</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">FAQs</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">Contact Us</a>
-                    </nav>
-                </div>
-            </div>
-        </div>
-
-        <div class="py-4 text-white-50" style="background-color: #002878;">
-            <div class="container-xl">
-                <div class="d-flex flex-column flex-sm-row justify-content-between text-center text-sm-start"
-                    style="font-size: 0.75rem;">
-                    <p class="mb-2 mb-sm-0">&copy; 2026 Mule Mart </p>
-                    <p>COPYRIGHT MULEMART.COM. ALL RIGHTS RESERVED</p>
-                </div>
-            </div>
-        </div>
-    </footer>
+    {% include '_footer.html' %}
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"

--- a/app/templates/inbox.html
+++ b/app/templates/inbox.html
@@ -61,47 +61,7 @@
 
     <!-- End of Main Content -->
 
-    <footer class="bg-light border-top mt-5 pt-5">
-        <div class="container-xl py-5">
-            <div class="row justify-content-between align-items-center gy-4">
-
-                <div class="col-md-6 col-lg-5">
-                    <h3 class="fs-2 fw-bold text-dark mb-2">Sign up for our newsletter</h3>
-                    <p class="text-secondary mb-4">Be the first to know about our special offers, news, and updates.</p>
-                    <form class="d-flex gap-2">
-                        <input type="email" placeholder="Email Address" class="form-control py-3">
-                        <button type="submit" class="btn btn-dark px-4">
-                            Sign Up
-                        </button>
-                    </form>
-                </div>
-
-                <div class="col-md-6 col-lg-auto">
-                    <nav class="d-flex flex-wrap justify-content-center justify-content-md-end gap-3 gap-lg-4">
-                        <a href="{{ url_for('main.home') }}"
-                            class="text-secondary text-decoration-none fw-medium">Home</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">About</a>
-                        <a href="{{ url_for('main.buy_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Browse Items</a>
-                        <a href="{{ url_for('main.post_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Post an Item</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">FAQs</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">Contact Us</a>
-                    </nav>
-                </div>
-            </div>
-        </div>
-
-        <div class="py-4 text-white-50" style="background-color: #002878;">
-            <div class="container-xl">
-                <div class="d-flex flex-column flex-sm-row justify-content-between text-center text-sm-start"
-                    style="font-size: 0.75rem;">
-                    <p class="mb-2 mb-sm-0">&copy; 2026 Mule Mart </p>
-                    <p>COPYRIGHTS MULEMART.COM. ALL RIGHTS RESERVED</p>
-                </div>
-            </div>
-        </div>
-    </footer>
+    {% include '_footer.html' %}
 
     <!-- Load Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"

--- a/app/templates/item_details.html
+++ b/app/templates/item_details.html
@@ -89,47 +89,7 @@
         </div>
     </main>
 
-    <footer class="bg-light border-top mt-5 pt-5">
-        <div class="container-xl py-5">
-            <div class="row justify-content-between align-items-center gy-4">
-
-                <div class="col-md-6 col-lg-5">
-                    <h3 class="fs-2 fw-bold text-dark mb-2">Sign up for our newsletter</h3>
-                    <p class="text-secondary mb-4">Be the first to know about our special offers, news, and updates.</p>
-                    <form class="d-flex gap-2">
-                        <input type="email" placeholder="Email Address" class="form-control py-3">
-                        <button type="submit" class="btn btn-dark px-4">
-                            Sign Up
-                        </button>
-                    </form>
-                </div>
-
-                <div class="col-md-6 col-lg-auto">
-                    <nav class="d-flex flex-wrap justify-content-center justify-content-md-end gap-3 gap-lg-4">
-                        <a href="{{ url_for('main.home') }}"
-                            class="text-secondary text-decoration-none fw-medium">Home</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">About</a>
-                        <a href="{{ url_for('main.buy_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Browse Items</a>
-                        <a href="{{ url_for('main.post_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Post an Item</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">FAQs</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">Contact Us</a>
-                    </nav>
-                </div>
-            </div>
-        </div>
-
-        <div class="py-4 text-white-50" style="background-color: #002878;">
-            <div class="container-xl">
-                <div class="d-flex flex-column flex-sm-row justify-content-between text-center text-sm-start"
-                    style="font-size: 0.75rem;">
-                    <p class="mb-2 mb-sm-0">&copy; 2026 Mule Mart </p>
-                    <p>COPYRIGHTS MULEMART.COM. ALL RIGHTS RESERVED</p>
-                </div>
-            </div>
-        </div>
-    </footer>
+    {% include '_footer.html' %}
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"

--- a/app/templates/my_listings.html
+++ b/app/templates/my_listings.html
@@ -252,6 +252,7 @@
         }
     </script>
 
+    {% include '_footer.html' %}
 </body>
 
 </html>

--- a/app/templates/my_orders.html
+++ b/app/templates/my_orders.html
@@ -161,9 +161,7 @@
 
     </main>
 
-    <footer class="border-top mt-5 py-4 bg-white text-center text-muted small">
-        &copy; 2026 Mule Mart. All rights reserved.
-    </footer>
+    {% include '_footer.html' %}
 
 </body>
 

--- a/app/templates/order_page.html
+++ b/app/templates/order_page.html
@@ -115,14 +115,11 @@
 
         </div>
 
-        <p class="text-center text-muted small mt-4">
-            COPYRIGHTS MULEMART.COM. ALL RIGHTS RESERVED
-        </p>
-
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
+    {% include '_footer.html' %}
 </body>
 
 </html>

--- a/app/templates/post_new_item.html
+++ b/app/templates/post_new_item.html
@@ -144,47 +144,7 @@
         </form>
     </main>
 
-    <footer class="bg-light border-top mt-5 pt-5">
-        <div class="container-xl py-5">
-            <div class="row justify-content-between align-items-center gy-4">
-
-                <div class="col-md-6 col-lg-5">
-                    <h3 class="fs-2 fw-bold text-dark mb-2">Sign up for our newsletter</h3>
-                    <p class="text-secondary mb-4">Be the first to know about our special offers, news, and updates.</p>
-                    <form id="newsletter-form" class="d-flex gap-2">
-                        <input type="email" placeholder="Email Address" class="form-control py-3">
-                        <button type="submit" class="btn btn-dark px-4">
-                            Sign Up
-                        </button>
-                    </form>
-                </div>
-
-                <div class="col-md-6 col-lg-auto">
-                    <nav class="d-flex flex-wrap justify-content-center justify-content-md-end gap-3 gap-lg-4">
-                        <a href="{{ url_for('main.home') }}"
-                            class="text-secondary text-decoration-none fw-medium">Home</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">About</a>
-                        <a href="{{ url_for('main.buy_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Browse Items</a>
-                        <a href="{{ url_for('main.post_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Post an Item</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">FAQs</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">Contact Us</a>
-                    </nav>
-                </div>
-            </div>
-        </div>
-
-        <div class="py-4 text-white-50" style="background-color: #002878;">
-            <div class="container-xl">
-                <div class="d-flex flex-column flex-sm-row justify-content-between text-center text-sm-start"
-                    style="font-size: 0.75rem;">
-                    <p class="mb-2 mb-sm-0">&copy; 2026 Mule Mart</p>
-                    <p>COPYRIGHTS MULEMART.COM. ALL RIGHTS RESERVED</p>
-                </div>
-            </div>
-        </div>
-    </footer>
+    {% include '_footer.html' %}
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -365,6 +365,8 @@
 
     </script>
 
+    {% include "_footer.html" %}
+
 </body>
 
 </html>

--- a/app/templates/sellers_details.html
+++ b/app/templates/sellers_details.html
@@ -86,47 +86,7 @@
     </main>
     <!-- End of Main Content -->
 
-    <footer class="bg-light border-top mt-5 pt-5">
-        <div class="container-xl py-5">
-            <div class="row justify-content-between align-items-center gy-4">
-
-                <div class="col-md-6 col-lg-5">
-                    <h3 class="fs-2 fw-bold text-dark mb-2">Sign up for our newsletter</h3>
-                    <p class="text-secondary mb-4">Be the first to know about our special offers, news, and updates.</p>
-                    <form class="d-flex gap-2">
-                        <input type="email" placeholder="Email Address" class="form-control py-3">
-                        <button type="submit" class="btn btn-dark px-4">
-                            Sign Up
-                        </button>
-                    </form>
-                </div>
-
-                <div class="col-md-6 col-lg-auto">
-                    <nav class="d-flex flex-wrap justify-content-center justify-content-md-end gap-3 gap-lg-4">
-                        <a href="{{ url_for('main.home') }}"
-                            class="text-secondary text-decoration-none fw-medium">Home</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">About</a>
-                        <a href="{{ url_for('main.buy_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Browse Items</a>
-                        <a href="{{ url_for('main.post_item') }}"
-                            class="text-secondary text-decoration-none fw-medium">Post an Item</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">FAQs</a>
-                        <a href="#" class="text-secondary text-decoration-none fw-medium">Contact Us</a>
-                    </nav>
-                </div>
-            </div>
-        </div>
-
-        <div class="py-4 text-white-50" style="background-color: #002878;">
-            <div class="container-xl">
-                <div class="d-flex flex-column flex-sm-row justify-content-between text-center text-sm-start"
-                    style="font-size: 0.75rem;">
-                    <p class="mb-2 mb-sm-0">&copy; 2026 Mule Mart</p>
-                    <p>COPYRIGHTS MULEMART.COM. ALL RIGHTS RESERVED</p>
-                </div>
-            </div>
-        </div>
-    </footer>
+    {% include '_footer.html' %}
 
     <!-- Load Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"


### PR DESCRIPTION
## Description
This PR adds a reusable shared footer component and applies it consistently across all pages.
It resolves the issue of duplicated inline footer markup by introducing a single footer include, similar to how the navbar is handled, improving maintainability and visual consistency.

## Related Issues
Closes #86 

## Changes Made
- [x] Created a reusable shared footer component (app/templates/_footer.html)
- [x] Replaced duplicated inline footers across all templates with the shared footer component

## Testing & Verification
- Ran full existing test suite (`pytest tests/`) — all 116 tests passed with no regressions
- Manually verified footer rendering across all major pages:
  - Home
  - Browse Items
  - Post Item
  - Item Details
  - Orders, Listings, Favorites, Chat, and Contact pages

Confirmed:
- [x] Footer layout is consistent across pages
- [x] “Back to top” button works as expected
- [x] No console errors or layout regressions introduced

## Checklist
- [x] I have performed a self-review of my own code
- [x] Existing test suite passes (no regressions introduced)
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
