### PR TITLE
Fix/show cancelled rejected orders

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -266,7 +266,7 @@ def my_listings():
     pending_orders = [o for o in incoming_orders if o.status == "pending"]
     approved_orders = [o for o in incoming_orders if o.status == "approved"]
     completed_orders = [o for o in incoming_orders if o.status == "completed"]
-    cancelled_orders = [o for o in incoming_orders if o.status == "cancelled"]
+    inactive_orders = [o for o in incoming_orders if o.status in ("cancelled", "rejected")]
 
     return render_template(
         "my_listings.html",
@@ -274,7 +274,7 @@ def my_listings():
         pending_orders=pending_orders,
         approved_orders=approved_orders,
         completed_orders=completed_orders,
-        cancelled_orders=cancelled_orders,
+        inactive_orders=inactive_orders,
         current_search=search,
     )
 
@@ -334,6 +334,28 @@ def reject_order(order_id):
 
     flash("Order has been rejected.", "success")
     return redirect(url_for("main.my_listings"))
+
+
+@main.route("/orders/<int:order_id>/cancel", methods=["POST"])
+@login_required
+def cancel_order(order_id):
+    order = Order.query.get_or_404(order_id)
+
+    if order.buyer_id != current_user.id:
+        abort(403)
+
+    if order.status != "pending":
+        return jsonify({"success": False})
+
+    try:
+        order.status = "cancelled"
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        current_app.logger.exception("Error cancelling order")
+        return jsonify({"success": False})
+
+    return jsonify({"success": True})
 
 
 @main.route("/mark_sold/<int:order_id>", methods=["POST"])
@@ -522,14 +544,18 @@ def my_orders():
     pending_orders = [o for o in orders if o.status == "pending"]
     approved_orders = [o for o in orders if o.status == "approved"]
     completed_orders = [o for o in orders if o.status == "completed"]
-    cancelled_orders = [o for o in orders if o.status == "cancelled"]
+
+    # inactive orders
+    cancelled_or_rejected_orders = [
+        o for o in orders if o.status in ("cancelled", "rejected")
+    ]
 
     return render_template(
         "my_orders.html",
         pending_orders=pending_orders,
         approved_orders=approved_orders,
         completed_orders=completed_orders,
-        cancelled_orders=cancelled_orders,
+        cancelled_or_rejected_orders=cancelled_or_rejected_orders,
         current_search=search,
     )
 

--- a/app/main.py
+++ b/app/main.py
@@ -266,7 +266,9 @@ def my_listings():
     pending_orders = [o for o in incoming_orders if o.status == "pending"]
     approved_orders = [o for o in incoming_orders if o.status == "approved"]
     completed_orders = [o for o in incoming_orders if o.status == "completed"]
-    inactive_orders = [o for o in incoming_orders if o.status in ("cancelled", "rejected")]
+    inactive_orders = [
+        o for o in incoming_orders if o.status in ("cancelled", "rejected")
+    ]
 
     return render_template(
         "my_listings.html",

--- a/app/templates/my_listings.html
+++ b/app/templates/my_listings.html
@@ -164,7 +164,7 @@
         {% if inactive_orders %}
         <div class="mb-5">
             <h3 class="fw-bold mb-3 text-muted">
-                Cancelled / Rejected Orders
+                Cancelled & Rejected Orders
             </h3>
 
             <div class="row g-3">

--- a/app/templates/my_listings.html
+++ b/app/templates/my_listings.html
@@ -157,6 +157,53 @@
         <hr class="my-5">
         {% endif %}
 
+
+        <!-- ============================= -->
+        <!-- CANCELLED / REJECTED ORDERS -->
+        <!-- ============================= -->
+        {% if inactive_orders %}
+        <div class="mb-5">
+            <h3 class="fw-bold mb-3 text-muted">
+                Cancelled / Rejected Orders
+            </h3>
+
+            <div class="row g-3">
+                {% for order in inactive_orders %}
+                <div class="col-md-6 col-lg-4">
+                    <div class="card shadow-sm border-0 p-3 opacity-50">
+
+                        <h5 class="fw-bold text-secondary mb-1">
+                            {{ order.item.title }}
+                        </h5>
+
+                        <p class="small text-muted mb-1">
+                            Buyer: <strong>{{ order.buyer.name }}</strong>
+                        </p>
+
+                        <p class="small text-muted mb-2">
+                            {% if order.status == "cancelled" %}
+                                Cancelled by buyer
+                            {% else %}
+                                Rejected by you
+                            {% endif %}
+                        </p>
+
+                        {% if order.status == "rejected" %}
+                        <span class="badge bg-danger align-self-start">Rejected</span>
+                        {% else %}
+                        <span class="badge bg-dark align-self-start">Cancelled</span>
+                        {% endif %}
+
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+
+        <hr class="my-5">
+        {% endif %}
+
+
         <!-- ============================= -->
         <!-- USER LISTINGS -->
         <!-- ============================= -->

--- a/app/templates/my_orders.html
+++ b/app/templates/my_orders.html
@@ -168,7 +168,7 @@
         <!-- CANCELLED / REJECTED ORDERS -->
         <div class="mb-5">
             <h5 class="fw-bold text-uppercase text-muted mb-3 border-bottom pb-2">
-                Cancelled / Rejected Orders
+                Cancelled & Rejected Orders
             </h5>
 
             {% if cancelled_or_rejected_orders %}

--- a/app/templates/my_orders.html
+++ b/app/templates/my_orders.html
@@ -79,6 +79,12 @@
                         {% if order.notes %}
                         <p class="mb-1 text-muted small fst-italic">"{{ order.notes }}"</p>
                         {% endif %}
+
+                        <button class="btn btn-outline-danger btn-sm fw-medium mt-2"
+                                onclick="cancelOrder({{ order.id }})">
+                            <i class="bi bi-x-circle me-1"></i> Cancel Request
+                        </button>
+
                     </div>
 
                 </div>
@@ -159,6 +165,43 @@
             {% endif %}
         </div>
 
+        <!-- CANCELLED / REJECTED ORDERS -->
+        <div class="mb-5">
+            <h5 class="fw-bold text-uppercase text-muted mb-3 border-bottom pb-2">
+                Cancelled / Rejected Orders
+            </h5>
+
+            {% if cancelled_or_rejected_orders %}
+            {% for order in cancelled_or_rejected_orders %}
+            <div class="card shadow-sm border-0 mb-3 opacity-50">
+                <div class="card-body p-3 d-flex align-items-center gap-3">
+
+                    <div class="flex-grow-1">
+                        <h6 class="fw-bold mb-1 text-muted">
+                            {{ order.item.title }}
+                        </h6>
+                        <small class="text-muted">
+                            Status: {{ order.status | capitalize }}
+                        </small>
+                    </div>
+
+                    {% if order.status == "rejected" %}
+                    <span class="badge bg-danger rounded-pill">Rejected</span>
+                    {% else %}
+                    <span class="badge bg-dark rounded-pill">Cancelled</span>
+                    {% endif %}
+
+                </div>
+            </div>
+            {% endfor %}
+            {% else %}
+            <p class="text-muted small fst-italic">
+                No cancelled or rejected orders.
+            </p>
+            {% endif %}
+        </div>
+
+
     </main>
 
     {% include '_footer.html' %}
@@ -170,12 +213,26 @@
         fetch(`/confirm_order/${orderId}`, {
             method: "POST",
         })
-            .then(res => res.json())
-            .then(data => {
-                if (data.success) {
-                    location.reload();
-                }
-            });
+        .then(res => res.json())
+        .then(data => {
+            if (data.success) {
+                location.reload();
+            }
+        });
+    }
+
+    function cancelOrder(orderId) {
+        fetch(`/orders/${orderId}/cancel`, {
+            method: "POST",
+        })
+        .then(res => res.json())
+        .then(data => {
+            if (data.success) {
+                location.reload();
+            } else {
+                alert("Could not cancel order.");
+            }
+        });
     }
 </script>
 

--- a/tests/test_main_and_orders.py
+++ b/tests/test_main_and_orders.py
@@ -399,6 +399,35 @@ def test_my_orders_grouping(client, logged_in_user, sample_item, app):
     assert b"completed" in resp.data.lower()
 
 
+def test_my_orders_shows_cancelled_and_rejected_orders(
+    client, logged_in_user, sample_item, app
+):
+    """
+    Cancelled and rejected orders should appear in My Orders history.
+    """
+    with app.app_context():
+        cancelled = Order(
+            buyer_id=logged_in_user.id,
+            item_id=sample_item.id,
+            location="loc",
+            status="cancelled",
+        )
+        rejected = Order(
+            buyer_id=logged_in_user.id,
+            item_id=sample_item.id,
+            location="loc",
+            status="rejected",
+        )
+        db.session.add_all([cancelled, rejected])
+        db.session.commit()
+
+    resp = client.get("/my_orders")
+
+    assert resp.status_code == 200
+    assert b"cancelled" in resp.data.lower()
+    assert b"rejected" in resp.data.lower()
+
+
 def test_confirm_order_authorized(client, logged_in_user, sample_item, app):
     with app.app_context():
         o = Order(


### PR DESCRIPTION
## Description
This PR improves order history transparency by displaying cancelled and rejected orders
in both the buyer (“My Orders”) and seller (“My Listings”) views.

Previously, rejected or cancelled orders were not visible to users, which made it difficult
to track the full lifecycle of an order. This change ensures users can always see the outcome
of their requests, even when an order does not complete.

## Related Issues
Closes #100 

## Changes Made
- Display cancelled and rejected orders in the buyer “My Orders” page under a dedicated section
- Display cancelled and rejected orders in the seller “My Listings” page using a unified inactive orders group
- Add buyer-side ability to cancel pending orders
- Introduce a backend route to handle order cancellation securely
- Add test coverage to verify cancelled and rejected orders appear in order history

## Testing & Verification
- Added a unit test to ensure cancelled and rejected orders appear in the My Orders view
- Ran the full test suite locally (`pytest`) — all tests pass
- Verified formatting with `black --check .`
- Manually tested order lifecycle in the UI:
  - Pending → Approved → Completed
  - Pending → Cancelled (buyer)
  - Pending → Rejected (seller)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
